### PR TITLE
Fixes permission issue with Docker volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /wiki
 
 COPY --from=builder /app/wiki-go .
 
-RUN chown -R appuser:appgroup /wiki && chmod -R 755 /wiki
+RUN mkdir /wiki/data && chown -R appuser:appgroup /wiki && chmod -R 755 /wiki
 
 USER appuser
 


### PR DESCRIPTION
When I use Docker volumes, the container returns the error message “Error loading config:open data/config.yaml: permission denied.” It is started using the following docker-compose:

```yaml
services:
  wiki-go:
    image: leomoonstudios/wiki-go:latest
    container_name: wiki-go
    ports:
      - 9090:8080
    volumes:
      - wiki-data:/wiki/data
    restart: unless-stopped

volumes:
  wiki-data:
```

If the “data” folder already exists in the image and the permissions are set as implemented by the changes, it will work.