### PR TITLE
Make config.ConfigFilePath 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ cmd
 !SECURITY.md
 # for quick python tests
 /.venv
+
+# emacs backup files
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+# Use vendored dependencies
+GOFLAGS=-mod=vendor
+
+# build directory
+BUILD_DIR = build
+
+# get version from git
+VERSION = $(shell git describe --tags --always 2>/dev/null || echo "dev")
+
+LDFLAGS = "-X 'wiki-go/internal/version.Version=$(VERSION)' -s -w -extldflags=-static -linkmode 'external'"
+BUILDTAGS = -tags netgo,usergo -trimpath -gcflags=all="-l -B -C"
+
+all:
+	@echo "Build this program for your architecture:"
+	@echo " - make linux_amd64"
+	@echo " - make linux_386"
+	@echo " - make linux_arm64"
+	@echo " - make linux_arm5"
+	@echo " - make linux_arm6"
+	@echo " - make linux_arm7"
+	@echo " - make linux_s390x"
+	@echo " - make windows_amd64"
+	@echo " - make windows_arm64"
+	@echo " - make macos_arm64"
+
+prepare: 
+	mkdir -p $(BUILD_DIR)
+	find $(BUILD_DIR) -mindepth 1 -and -not -name ".gitkeep" -and -not -path $(BUILD_DIR)/data -and -not -path $(BUILD_DIR)/data/* -and -delete
+	@echo "Building version: " $(VERSION)
+
+linux_amd64: prepare
+	@echo "Building for Linux (amd64)..."
+	GOOS=linux GOARCH=amd64 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-amd64 .
+
+linux_386: prepare
+	@echo "Building for Linux (386)..."
+	GOOS=linux GOARCH=386 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-386 .
+
+linux_arm64: prepare
+	@echo "Building for Linux (arm64)..."
+	GOOS=linux GOARCH=arm64 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-arm64 .
+
+linux_arm5: prepare
+	@echo "Building for Linux ARMv5..."
+	GOOS=linux GOARCH=arm GOARM=5 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-armv5 .
+
+linux_arm6: prepare
+	@echo "Building for Linux ARMv6..."
+	GOOS=linux GOARCH=arm GOARM=6 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-armv6 .
+
+linux_arm7: prepare
+	@echo "Building for Linux ARMv7..."
+	GOOS=linux GOARCH=arm GOARM=7 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-armv7 .
+
+linux_s390x: prepare
+	@echo "Building for Linux (s390x)..."
+	GOOS=linux GOARCH=s390x go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-linux-s390x .
+
+windows_amd64: prepare
+	@echo "Building for Windows (amd64)..."
+	GOOS=windows GOARCH=amd64 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-windows-amd64.exe .
+
+windows_arm64: prepare
+	@echo "Building for Windows (arm64)..."
+	GOOS=windows GOARCH=arm64 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-windows-arm64.exe .
+
+macos_arm64: prepare
+	@echo "Building for macOS (amd64)..."
+	GOOS=darwin GOARCH=amd64 go build $(BUILDTAGS) -ldflags $(LDFLAGS) -o $(BUILD_DIR)/wiki-go-mac-amd64 .
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,9 @@ import (
 )
 
 // ConfigFilePath defines the global path to the configuration file
-const ConfigFilePath = "data/config.yaml"
+var (
+	ConfigFilePath string = "data/config.yaml"
+)
 
 // User represents a user with authentication credentials
 type User struct {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os"
 	"fmt"
+	"flag"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -18,6 +20,13 @@ import (
 )
 
 func main() {
+	configfilepath := flag.String("configfile",
+		GetEnvString("CONFIGFILE", config.ConfigFilePath),
+		"where to find config.yaml")
+	flag.Parse()
+
+	config.ConfigFilePath = *configfilepath
+	
 	// Migrate user roles from old IsAdmin to new role-based system
 	if err := migration.MigrateUserRoles(config.ConfigFilePath); err != nil {
 		log.Fatal("Error migrating user roles:", err)
@@ -64,4 +73,12 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+}
+
+func GetEnvString(name, defaultvalue string) string {
+	value, ok := os.LookupEnv(name)
+	if ! ok {
+		return defaultvalue
+	}
+	return value
 }


### PR DESCRIPTION
Hello, this pull request adds a command line option "-configfile" with a path to config.yaml so it can be a Docker secret (which always reside in the /run/secrets/ directory). The same can also be set with the environment variable "CONFIGFILE". If neither the command line option nor the environment variable are found, the behavior of the program rests unchanged and the value of the previous constant is used, "data/config.yaml". The constant config.ConfigFilePath had to be changed into a variable for this new behaviour. 

I've also added a Makefile with instructions to build wiki-go into a statically linked executable, thus eliminating the need for external libraries. As such, wiki-go can be used standalone in a Docker container "FROM scratch" without the need to include shared objects. Also, my Makefile uses make targets for the different GOOS and GOARCH build targets. 

Thank you very much for this great software, all the best, SP. 