### PR TITLE
made password hash strength (bcrypt cost factor / rounds) configurabl…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	Users       []User       `yaml:"users"`
 	AccessRules []AccessRule `yaml:"access_rules,omitempty"`
 	Security    struct {
+		PasswordStrength int `yaml:"passwordstrength"`
 		LoginBan struct {
 			Enabled           bool `yaml:"enabled"`
 			MaxFailures       int  `yaml:"max_failures"`
@@ -115,6 +116,7 @@ func LoadConfig(path string) (*Config, error) {
 	config.Users = []User{}        // Initialize empty users array
 
 	// Security defaults
+	config.Security.PasswordStrength = 14
 	config.Security.LoginBan.Enabled = true
 	config.Security.LoginBan.MaxFailures = 5
 	config.Security.LoginBan.WindowSeconds = 180
@@ -132,7 +134,7 @@ func LoadConfig(path string) (*Config, error) {
 			}
 
 			// Hash the default admin password
-			hashedPassword, err := crypto.HashPassword("admin")
+			hashedPassword, err := crypto.HashPassword("admin", config.Security.PasswordStrength)
 			if err != nil {
 				return nil, err
 			}
@@ -186,6 +188,7 @@ func LoadConfig(path string) (*Config, error) {
 				config.Wiki.MaxVersions,
 				config.Wiki.MaxUploadSize,
 				config.Wiki.Language,
+				config.Security.PasswordStrength,
 				config.Security.LoginBan.Enabled,
 				config.Security.LoginBan.MaxFailures,
 				config.Security.LoginBan.WindowSeconds,
@@ -259,6 +262,8 @@ wiki:
     # Default language for the wiki interface (en, es, etc.)
     language: "%s"
 security:
+    # cost factor for bcrypt password hashing
+    passwordstrength: %d
     login_ban:
         # Enable protection against brute force login attacks
         enabled: %t
@@ -346,6 +351,7 @@ func SaveConfig(cfg *Config, w io.Writer) error {
 		cfg.Wiki.MaxVersions,
 		cfg.Wiki.MaxUploadSize,
 		cfg.Wiki.Language,
+		cfg.Security.PasswordStrength,
 		cfg.Security.LoginBan.Enabled,
 		cfg.Security.LoginBan.MaxFailures,
 		cfg.Security.LoginBan.WindowSeconds,

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -5,8 +5,8 @@ import (
 )
 
 // HashPassword creates a bcrypt hash of the password
-func HashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+func HashPassword(password string, passwordstrength int) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), passwordstrength)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/security_settings.go
+++ b/internal/handlers/security_settings.go
@@ -12,6 +12,7 @@ var securityMu sync.Mutex
 
 // SecuritySettings represents the JSON payload for security settings.
 type SecuritySettings struct {
+	PasswordStrength int `yaml:"passwordstrength"`
     LoginBan struct {
         Enabled           bool `json:"enabled"`
         MaxFailures       int  `json:"max_failures"`
@@ -37,6 +38,7 @@ func handleGetSecurity(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json")
 
     var resp SecuritySettings
+	resp.PasswordStrength = cfg.Security.PasswordStrength
     resp.LoginBan.Enabled = cfg.Security.LoginBan.Enabled
     resp.LoginBan.MaxFailures = cfg.Security.LoginBan.MaxFailures
     resp.LoginBan.WindowSeconds = cfg.Security.LoginBan.WindowSeconds
@@ -63,6 +65,7 @@ func handleUpdateSecurity(w http.ResponseWriter, r *http.Request) {
     defer securityMu.Unlock()
 
     // Update cfg in-memory
+	cfg.Security.PasswordStrength = req.PasswordStrength
     cfg.Security.LoginBan.Enabled = req.LoginBan.Enabled
     cfg.Security.LoginBan.MaxFailures = req.LoginBan.MaxFailures
     cfg.Security.LoginBan.WindowSeconds = req.LoginBan.WindowSeconds

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -119,7 +119,7 @@ func CreateUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Hash the password
-	hashedPassword, err := crypto.HashPassword(req.Password)
+	hashedPassword, err := crypto.HashPassword(req.Password, cfg.Security.PasswordStrength)
 	if err != nil {
 		sendJSONError(w, "Failed to hash password", http.StatusInternalServerError, err.Error())
 		return
@@ -201,7 +201,7 @@ func UpdateUserHandler(w http.ResponseWriter, r *http.Request) {
 			updatedConfig.Users[i].Groups = req.Groups
 			// Update password if provided
 			if req.NewPassword != "" {
-				hashedPassword, err := crypto.HashPassword(req.NewPassword)
+				hashedPassword, err := crypto.HashPassword(req.NewPassword, updatedConfig.Security.PasswordStrength)
 				if err != nil {
 					sendJSONError(w, "Failed to hash password", http.StatusInternalServerError, err.Error())
 					return


### PR DESCRIPTION
…e in config.yaml

This PR adds a configuration variable "PasswordStrength" (YAML: "passwordstrength") under the "Security" settings to configure the cost factor for the bcrypt hash algorithm for passwords. 

The major feature of bcrypt is that the cost (i.e. the time) to calculate hashes is configurable, so that the strength of the password hashes can be adjusted according to rising capabilities of hard- and software. 

OWASP recommends [1] a minimum of 10 when I write this, but a default value of 14 seems more appropriate to me and I myself rather use 16 in my production settings. 

Existing passwords will not need an update, but will be hashed for the configured value upon change. 

[1] https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt
