### PR TITLE
Bad links

### DIFF
--- a/internal/goldext/link.go
+++ b/internal/goldext/link.go
@@ -3,6 +3,7 @@ package goldext
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -146,6 +147,14 @@ func LinkPreprocessor(markdown string, docPath string) string {
 
 				if isLocalPath(path) {
 					path = resolveLocalPath(path, docPath)
+				}
+				// Only absolute paths now -- resolveLocalPath ought to have
+				// made this an absolute local path, if it was a local path at
+				// all.
+				if strings.HasPrefix(path, "/") {
+					if _, err := os.Stat("data/documents" + path); os.IsNotExist(err) {
+						return "<span class=\"notfound\">[" + text + "](" + path + ")</span>"
+					}
 				}
 
 				return "[" + text + "](" + path + ")"

--- a/internal/resources/static/css/typography.css
+++ b/internal/resources/static/css/typography.css
@@ -195,6 +195,10 @@ pre[class*="language-"] > code {
     text-decoration: none;
 }
 
+.markdown-content span.notfound a {
+    color: red;
+}
+
 .markdown-content a:hover {
     color: var(--primary-hover);
     text-decoration: underline;

--- a/internal/resources/static/css/typography.css
+++ b/internal/resources/static/css/typography.css
@@ -196,7 +196,7 @@ pre[class*="language-"] > code {
 }
 
 .markdown-content span.notfound a {
-    color: red;
+    color: var(--danger-color);
 }
 
 .markdown-content a:hover {


### PR DESCRIPTION
Solves a portion of https://github.com/leomoon-studios/wiki-go/issues/118 , where links that point to not-yet-created pages should highlight in red.

I hacked this up in about thirty minutes, never having touched Go before, because this is a feature I wanted for my self-hosted copy of the project, which is for tracking a table-top campaign world. Redlinks are a core part of the wiki experience!

Anyways, some architectural concerns with this pull request:

1. importing "os" in the goldext package and checking for data-document-existence seems to violate a separation of concerns. However, internal/goldext/shortcodes.go also does file-checks, though not for user-generated files.
2. Instead of doing anything smart of logical, when we do find that the linked document ref doesn't exist, we just slap a `<span class="notfound">` right into the processed markdown. This _works_ but is a bit junky.
3. Not sure where was a good place to put the CSS definition, or if `.markdown-content span.notfound a` was the right level of specificity for the selector.

Anyways, I hope this pull request finds you well.