### PR TITLE
Adds Open Graph meta tags to head section in base template

### DIFF
--- a/internal/resources/templates/base.html
+++ b/internal/resources/templates/base.html
@@ -15,6 +15,20 @@
     {{if hasFavicon .Config.Wiki.RootDir "svg"}}<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">{{end}}
     {{if hasFavicon .Config.Wiki.RootDir "png"}}<link rel="icon" href="/static/favicon.png" type="image/png">{{end}}
     <link rel="manifest" href="/manifest.json">
+    <!-- Open Graph properties -->
+    <meta property="og:title" content="{{.Config.Wiki.Title}}" />
+    {{if eq .CurrentDir.Path "/"}}
+        <meta property="og:description" content="{{.Config.Wiki.Notice}}" />
+        <meta property="og:type" content="website" />
+    {{else}}
+        <meta property="og:description" content="{{.CurrentDir.Title}}" />
+        <meta property="og:type" content="article" />
+        <meta property="og:article:modified_time" content="{{formatTime .LastModified .Config.Wiki.Timezone "2006-01-02T15:04:05-0700"}}" />
+    {{end}}
+    {{$logoPath := hasLogo .Config.Wiki.RootDir}}
+    {{if $logoPath}}
+        <meta property="og:image" content="{{$logoPath}}" />
+    {{end}}
     <!-- Resource Hints - Preload critical resources for faster page load -->
     <link rel="preload" href="/static/css/theme.css?={{getVersion}}" as="style">
     <link rel="preload" href="/static/css/layout.css?={{getVersion}}" as="style">


### PR DESCRIPTION
Implements #142 .

I wanted the `og:description` tag for pages to include a slice of the content, such as `{{printf "%.70s" .Content}}`, but `.Content` already contained HTML tags by that point, and it looks like go/html's stripTags function is private. So I left well enough alone! Perhaps someone can take it over and drive that part across the finish line, but as someone who doesn't program Go often at all, I recuse myself.

For the main page, you get a Discord embed that looks like:

<img width="366" height="171" alt="image" src="https://github.com/user-attachments/assets/78fda1b5-9c83-410f-8fbc-a46418d46741" />

Which is the Title and Notice in config.yml, plus whatever's in `data/static/logo.(svg|png)` if present.

For documents, you get a Discord embed that looks like:

<img width="537" height="179" alt="image" src="https://github.com/user-attachments/assets/8a75182e-5fbe-45ad-a55e-7ea3213415d3" />

Telegram looks roughly similar:

<img width="589" height="231" alt="image" src="https://github.com/user-attachments/assets/070359c5-92e0-49bd-a43d-f451b4a5d0aa" />

Which is still the Title from config.yml, but also the Document title as the description. Pretty smooth!


Also I have learnt my lesson from #134 and squashed my commits before making a PR.