### PR TITLE
docs: add GROWTH.md community visibility playbook

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -1,0 +1,98 @@
+# GROWTH.md — Community Visibility Playbook
+
+> A practical guide to help wiki-go reach more self-hosters and documentation enthusiasts.
+
+## 📍 Positioning
+
+**One-liner:** The self-hosted wiki that just works — no database, no bloat, just Markdown.
+
+**Key differentiators vs alternatives:**
+| Feature | wiki-go | Outline | BookStack | WikiJS |
+|---------|---------|---------|-----------|--------|
+| Database required | ❌ None | ✅ Postgres | ✅ MySQL | ✅ Various |
+| Setup complexity | 🟢 Minimal | 🟡 Medium | 🟡 Medium | 🟡 Medium |
+| Flat-file storage | ✅ | ❌ | ❌ | ❌ |
+| Docker one-liner | ✅ | ✅ | ✅ | ✅ |
+| Self-contained binary | ✅ | ❌ | ❌ | ❌ |
+
+**Target audiences:**
+1. Self-hosters who want minimal maintenance
+2. Teams needing internal documentation without SaaS lock-in
+3. Developers who prefer flat-file/git-friendly storage
+4. Privacy-conscious users avoiding cloud wikis
+
+## 🎯 Quick Wins (Low Effort, High Impact)
+
+| Action | Expected Impact | Effort |
+|--------|-----------------|--------|
+| Add to [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) | ⭐⭐⭐ 50-100 stars | 30 min |
+| Post to r/selfhosted | ⭐⭐⭐ 30-80 stars | 20 min |
+| Add GitHub topics | ⭐⭐ Discoverability | 5 min |
+| Add "Made with" badges | ⭐ Social proof | 10 min |
+
+### GitHub Topics to Add
+```
+wiki, documentation, flat-file, self-hosted, golang, markdown, 
+knowledge-base, no-database, docker, personal-wiki
+```
+
+## 🚀 Launch Channels
+
+### Tier 1: High-Impact Communities
+1. **r/selfhosted** (800k+ members)
+   - Post type: "Show off your setup" with screenshot
+   - Best time: Tuesday-Thursday, 10am-2pm EST
+   - Title format: "Built a databaseless wiki in Go — wiki-go [open source]"
+
+2. **Hacker News - Show HN**
+   - Title: "Show HN: Wiki-Go – A flat-file wiki platform that needs no database"
+   - Best for: Technical audience, potential contributors
+   - Timing: Weekday mornings EST
+
+3. **awesome-selfhosted PR**
+   - Category: Wikis
+   - Template:
+   ```markdown
+   - [wiki-go](https://github.com/leomoon-studios/wiki-go) - Modern flat-file wiki with Markdown, full-text search, and zero database requirements. `MIT` `Go/Docker`
+   ```
+
+### Tier 2: Niche Communities
+- r/homelab — for Docker/self-hosting angle
+- r/golang — for Go developers
+- AlternativeTo.net — list as Confluence/Notion alternative
+- Docker Hub — ensure good description and tags
+
+### Tier 3: Content Marketing
+- Dev.to article: "Why I Built a Databaseless Wiki (and You Might Want One Too)"
+- Comparison post: "Wiki-Go vs BookStack vs Outline: Which Self-Hosted Wiki Fits Your Needs?"
+
+## 📈 90-Day Growth Targets
+
+| Milestone | Target | Current | Actions |
+|-----------|--------|---------|---------|
+| Day 30 | 700 ⭐ | 528 | awesome-selfhosted + r/selfhosted |
+| Day 60 | 900 ⭐ | — | HN Show HN + Dev.to content |
+| Day 90 | 1,200 ⭐ | — | Product Hunt launch (optional) |
+
+## 🔧 README Optimization Suggestions
+
+**Current strengths:**
+- ✅ Great feature list
+- ✅ Clear screenshots
+- ✅ Docker instructions
+
+**Potential improvements:**
+- Add a comparison table in README (vs Notion/Confluence/BookStack)
+- Add "Star History" badge
+- Add quick testimonials/use cases section
+- Consider a 30-second demo GIF at top
+
+## 📚 Resources
+
+For detailed launch tactics and templates:
+- [Open Source Marketing Playbook](https://github.com/Gingiris/gingiris-opensource)
+- [Product Hunt Launch Guide](https://github.com/Gingiris/gingiris-launch)
+
+---
+
+*This guide is a community contribution. Feel free to adapt it to your project's needs!*


### PR DESCRIPTION
As discussed in #156, this PR adds a GROWTH.md with practical growth tactics for wiki-go.

## What's included

- **Positioning** — how wiki-go differentiates from Outline/BookStack/WikiJS (the "no database" angle)
- **Quick wins table** — low-effort actions with expected star impact
- **Launch channels** — r/selfhosted, HN Show HN, awesome-selfhosted with templates
- **90-day targets** — milestones from 528 → 1,200 stars
- **README suggestions** — optional improvements for conversion

## Why this format

The guide is actionable and specific to wiki-go's positioning in the self-hosted wiki space. Happy to adjust based on your feedback!

Closes #156