### PR TITLE
Document missing keeploggedin boolean for API

### DIFF
--- a/rest-api-examples.http
+++ b/rest-api-examples.http
@@ -21,7 +21,8 @@ Content-Type: application/json
 
 {
   "username": "{{ username }}",
-  "password": "{{ password }}"
+  "password": "{{ password }}",
+  "keeploggedin" : false
 }
 
 ### Store the login session


### PR DESCRIPTION
if `keeploggedin` is `true`, the returned cookie will be valid for 30 days, just like when logging in interactively and the checkmark is set.