### PR TITLE
fix: format :::stats recent::: edit times in configured wiki timezone

### DIFF
--- a/internal/goldext/shortcodes.go
+++ b/internal/goldext/shortcodes.go
@@ -3,14 +3,52 @@ package goldext
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
+
+// wikiTimezone is the configured wiki timezone used when formatting
+// timestamps inside shortcodes (e.g. :::stats recent=N:::). It is
+// guarded by tzMu so callers in main can set it at startup while
+// requests format times concurrently.
+var (
+	tzMu         sync.RWMutex
+	wikiTimezone string
+)
+
+// SetWikiTimezone configures the timezone used by shortcodes that render
+// timestamps. It should be called once at startup, after config is loaded.
+func SetWikiTimezone(tz string) {
+	tzMu.Lock()
+	defer tzMu.Unlock()
+	wikiTimezone = tz
+}
+
+// formatModTime formats t using the configured wiki timezone. If no
+// timezone is configured or the configured value is invalid, it falls
+// back to UTC.
+func formatModTime(t time.Time, format string) string {
+	tzMu.RLock()
+	tz := wikiTimezone
+	tzMu.RUnlock()
+
+	if tz == "" {
+		return t.UTC().Format(format)
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		log.Printf("goldext: invalid wiki timezone %q: %v, falling back to UTC", tz, err)
+		return t.UTC().Format(format)
+	}
+	return t.In(loc).Format(format)
+}
 
 // ShortcodesPreprocessor processes shortcodes in markdown text
 // Supports: :::year:::, :::stats count=*:::, :::stats recent=N:::
@@ -155,10 +193,14 @@ func renderDocumentCount(w *strings.Builder, countParam string) {
 
 // renderRecentEdits renders the recent edits HTML
 func renderRecentEdits(w *strings.Builder, count int) {
-	// Get recent documents
-	docs := getRecentDocuments("data/documents", count)
+	renderRecentEditsFromDir(w, "data/documents", count)
+}
 
-	// Generate HTML for the recent edits
+// renderRecentEditsFromDir is the testable core of renderRecentEdits and
+// renders the list of recent edits from a given documents directory.
+func renderRecentEditsFromDir(w *strings.Builder, dirPath string, count int) {
+	docs := getRecentDocuments(dirPath, count)
+
 	w.WriteString("<div class=\"wiki-stats recent-edits\">\n")
 	w.WriteString("<h4>Recently Edited Documents</h4>\n")
 
@@ -168,16 +210,14 @@ func renderRecentEdits(w *strings.Builder, count int) {
 		w.WriteString("<ul>\n")
 
 		for _, doc := range docs {
-			// Create link to the document's folder
 			folderPath := "/" + doc.Path
 
-			// Structure with elements on one line
 			w.WriteString("<li>\n")
 			w.WriteString("  <div class=\"doc-info\">\n")
 			w.WriteString(fmt.Sprintf("    <a href=\"%s\">%s</a>\n", folderPath, doc.Title))
 			w.WriteString(fmt.Sprintf("    <span class=\"doc-path\">%s</span>\n", folderPath))
 			w.WriteString("  </div>\n")
-			w.WriteString(fmt.Sprintf("  <span class=\"edit-date\">%s</span>\n", doc.ModTime.Format("2006-01-02 15:04")))
+			w.WriteString(fmt.Sprintf("  <span class=\"edit-date\">%s</span>\n", formatModTime(doc.ModTime, "2006-01-02 15:04")))
 			w.WriteString("</li>\n")
 		}
 

--- a/internal/goldext/shortcodes_timezone_test.go
+++ b/internal/goldext/shortcodes_timezone_test.go
@@ -1,0 +1,80 @@
+package goldext
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeRecentDoc stages a document.md file in docDir with the given
+// title and mod time so renderRecentEditsFromDir picks it up.
+func writeRecentDoc(docDir, title string, modTime time.Time) error {
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(docDir, "document.md")
+	if err := os.WriteFile(path, []byte("# "+title+"\n"), 0o644); err != nil {
+		return err
+	}
+	return os.Chtimes(path, modTime, modTime)
+}
+
+func TestFormatModTime(t *testing.T) {
+	// Pick a moment that is in two different local dates depending on tz
+	// 2024-01-15 23:30 UTC is 2024-01-16 00:30 in Europe/Berlin (UTC+1)
+	// and 2024-01-15 15:30 in America/Los_Angeles.
+	moment := time.Date(2024, 1, 15, 23, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		tz   string
+		want string
+	}{
+		{name: "UTC", tz: "UTC", want: "2024-01-15 23:30"},
+		{name: "Berlin", tz: "Europe/Berlin", want: "2024-01-16 00:30"},
+		{name: "Los_Angeles", tz: "America/Los_Angeles", want: "2024-01-15 15:30"},
+		{name: "Empty falls back to UTC", tz: "", want: "2024-01-15 23:30"},
+		{name: "Invalid falls back to UTC", tz: "Not/AZone", want: "2024-01-15 23:30"},
+	}
+
+	prev := wikiTimezone
+	t.Cleanup(func() { SetWikiTimezone(prev) })
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetWikiTimezone(tc.tz)
+			got := formatModTime(moment, "2006-01-02 15:04")
+			if got != tc.want {
+				t.Fatalf("formatModTime(%q) = %q, want %q", tc.tz, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderRecentEditsUsesWikiTimezone(t *testing.T) {
+	prev := wikiTimezone
+	t.Cleanup(func() { SetWikiTimezone(prev) })
+
+	// Stage a single recent edit at a UTC time we can verify.
+	dir := t.TempDir()
+	docDir := dir + "/welcome"
+	if err := writeRecentDoc(docDir, "Welcome", time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("writeRecentDoc: %v", err)
+	}
+
+	SetWikiTimezone("Asia/Tokyo") // UTC+9
+	var buf strings.Builder
+	renderRecentEditsFromDir(&buf, dir, 5)
+	if !strings.Contains(buf.String(), "2024-06-01 19:00") {
+		t.Fatalf("expected JST-formatted time in output, got: %s", buf.String())
+	}
+
+	SetWikiTimezone("UTC")
+	buf.Reset()
+	renderRecentEditsFromDir(&buf, dir, 5)
+	if !strings.Contains(buf.String(), "2024-06-01 10:00") {
+		t.Fatalf("expected UTC-formatted time in output, got: %s", buf.String())
+	}
+}

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"wiki-go/internal/auth"
 	"wiki-go/internal/config"
+	"wiki-go/internal/goldext"
 	"wiki-go/internal/i18n"
 )
 
@@ -149,6 +150,10 @@ func UpdateWikiSettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Update the global config
 	*cfg = updatedConfig
+
+	// Apply updated timezone to shortcode rendering so :::stats recent:::
+	// reflects the new setting without requiring a restart.
+	goldext.SetWikiTimezone(updatedConfig.Wiki.Timezone)
 
 	// Send success response
 	w.Header().Set("Content-Type", "application/json")

--- a/main.go
+++ b/main.go
@@ -10,13 +10,11 @@ import (
 
 	"wiki-go/internal/auth"
 	"wiki-go/internal/config"
+	"wiki-go/internal/goldext"
 	"wiki-go/internal/handlers"
 	"wiki-go/internal/migration"
 	"wiki-go/internal/routes"
 	"wiki-go/internal/static"
-
-	// Import goldext package for its initialization side effects
-	_ "wiki-go/internal/goldext"
 )
 
 func main() {
@@ -42,6 +40,11 @@ func main() {
 	if err != nil {
 		log.Fatal("Error loading config:", err)
 	}
+
+	// Propagate wiki timezone to the goldext shortcode renderer so that
+	// :::stats recent=N::: formats edit times in the configured zone
+	// (consistent with formatTime used elsewhere in templates).
+	goldext.SetWikiTimezone(cfg.Wiki.Timezone)
 
 	// Initialize session store for persistent logins
 	sessionPath := filepath.Join(cfg.Wiki.RootDir, "temp", "sessions.json")


### PR DESCRIPTION
Fixes #167.

The `:::stats recent=N:::` shortcode formats document mod times with `t.Format("2006-01-02 15:04")`, which uses the server's local zone and ignores the configured `wiki.timezone`. Other timestamps go through `utils.FormatTimeInTimezone` via the `formatTime` template func, so the recent-edits list ends up out of sync with the rest of the page (the original report shows a UTC-configured wiki rendering CEST on "Recently Edited").

This wires the configured zone into the goldext package at startup (and re-applies it from the settings handler when timezone is updated), and uses it when formatting edit times, falling back to UTC for empty/invalid values. The change keeps the existing call signature, so other shortcodes are untouched.

Tests cover formatModTime across UTC/Berlin/Tokyo/Los_Angeles and an end-to-end render through a temp documents directory.