### PR TITLE
Add [[wikilink]] support

### DIFF
--- a/internal/goldext/load.go
+++ b/internal/goldext/load.go
@@ -6,6 +6,7 @@ package goldext
 // These variables ensure the preprocessors are available for registration
 // We don't actually use them directly, but they're needed for the compiler to include the preprocessors
 var (
+	_ = WikiLinkPreprocessor
 	_ = LinkPreprocessor
 	_ = MermaidPreprocessor
 	_ = DirectionPreprocessor
@@ -38,6 +39,7 @@ func init() {
 	RegisterPreprocessor(MermaidPreprocessor) // Process mermaid diagrams first
 
 	// Step 3: Register preprocessors that handle code blocks
+	RegisterPreprocessor(WikiLinkPreprocessor) // Convert [[wikilinks]] to Markdown links (before LinkPreprocessor so missing pages get .notfound styling)
 	RegisterPreprocessor(LinkPreprocessor)      // Process links and images
 	RegisterPreprocessor(DirectionPreprocessor) // Process RTL/LTR blocks
 	RegisterPreprocessor(MP4Preprocessor)       // Process MP4 video blocks

--- a/internal/goldext/wikilink.go
+++ b/internal/goldext/wikilink.go
@@ -1,0 +1,146 @@
+package goldext
+
+import (
+	"io/fs"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// documentsRoot is the directory Wiki-Go stores documents under, relative to
+// the working directory at runtime (matching LinkPreprocessor's convention).
+const documentsRoot = "data/documents"
+
+// wikiLinkRe matches [[target]] or [[target|label]]. The optional leading "!"
+// is captured so Obsidian-style embeds (![[...]]) can be left untouched.
+var wikiLinkRe = regexp.MustCompile(`(!?)\[\[([^\]\n]+)\]\]`)
+
+// WikiLinkPreprocessor converts [[wikilinks]] into standard Markdown links
+// before Goldmark runs. Examples:
+//
+//	[[02-entities/mass-spec]]            -> [mass-spec](/02-entities/mass-spec)
+//	[[mass-spec]]                        -> [mass-spec](/02-entities/mass-spec)  (resolved by name)
+//	[[02-entities/mass-spec|Mass Spec]]  -> [Mass Spec](/02-entities/mass-spec)
+//	[[notes#results]]                    -> [notes](/notes#results)
+//	[[#summary]]                         -> [summary](#summary)
+//
+// Targets that contain a slash are treated as explicit paths rooted at the wiki
+// root. A bare target (no slash) is resolved by name against the whole document
+// tree, wherever the page is filed (shortest path wins on duplicates), mirroring
+// Obsidian-style linking; if no page by that name exists it falls back to a
+// root-level path so the link still red-links via LinkPreprocessor. Display text
+// defaults to the last path segment. Content inside code spans/blocks and the
+// ![[...]] embed form are left untouched.
+func WikiLinkPreprocessor(markdown string, docPath string) string {
+	sections := splitCodeSections(markdown)
+
+	// Build the name->path index lazily, and only if a bare target appears.
+	var index map[string]string
+	var indexBuilt bool
+	resolveName := func(name string) string {
+		if !indexBuilt {
+			index = buildSlugIndex()
+			indexBuilt = true
+		}
+		return index[name]
+	}
+
+	for i := range sections {
+		if sections[i].isCode {
+			continue
+		}
+		sections[i].content = wikiLinkRe.ReplaceAllStringFunc(sections[i].content, func(match string) string {
+			parts := wikiLinkRe.FindStringSubmatch(match)
+			if len(parts) < 3 {
+				return match
+			}
+
+			// Leave embeds (![[...]]) for a future preprocessor to handle.
+			if parts[1] == "!" {
+				return match
+			}
+
+			// Split target and optional display label on the first "|".
+			target, label := parts[2], ""
+			if idx := strings.Index(target, "|"); idx != -1 {
+				target, label = target[:idx], target[idx+1:]
+			}
+			target = strings.TrimSpace(target)
+			label = strings.TrimSpace(label)
+			if target == "" {
+				return match
+			}
+
+			// Separate any #anchor from the page path.
+			pagePath, anchor := target, ""
+			if idx := strings.Index(target, "#"); idx != -1 {
+				pagePath, anchor = target[:idx], target[idx:]
+			}
+
+			// Default display text is the last path segment (anchor stripped).
+			if label == "" {
+				label = pagePath
+				if idx := strings.LastIndex(pagePath, "/"); idx != -1 {
+					label = pagePath[idx+1:]
+				}
+				if label == "" {
+					label = strings.TrimPrefix(anchor, "#")
+				}
+			}
+
+			// Resolve a bare name (no slash, not an in-page anchor, not already
+			// absolute) by looking it up anywhere in the document tree.
+			if pagePath != "" && !strings.HasPrefix(pagePath, "/") && !strings.Contains(pagePath, "/") {
+				if resolved := resolveName(pagePath); resolved != "" {
+					pagePath = resolved
+				}
+			}
+
+			// Build the URL. A bare "#anchor" stays an in-page link; everything
+			// else resolves to an absolute wiki path.
+			url := pagePath
+			if url != "" && !strings.HasPrefix(url, "/") {
+				url = "/" + url
+			}
+			url += anchor
+
+			return "[" + label + "](" + url + ")"
+		})
+	}
+
+	return joinSections(sections)
+}
+
+// buildSlugIndex walks the documents tree and maps each page's slug (its
+// directory name) to its path relative to the documents root. On duplicate
+// slugs the shortest path wins (fewest segments, then lexically smallest),
+// mirroring Obsidian's shortest-path name resolution.
+func buildSlugIndex() map[string]string {
+	index := make(map[string]string)
+	filepath.WalkDir(documentsRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != "document.md" {
+			return nil
+		}
+		rel, err := filepath.Rel(documentsRoot, filepath.Dir(p))
+		if err != nil || rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		slug := path.Base(rel)
+		if existing, ok := index[slug]; !ok || shorterPath(rel, existing) {
+			index[slug] = rel
+		}
+		return nil
+	})
+	return index
+}
+
+// shorterPath reports whether a should win over b as the resolution for a slug:
+// fewer path segments first, then lexically smallest for determinism.
+func shorterPath(a, b string) bool {
+	if na, nb := strings.Count(a, "/"), strings.Count(b, "/"); na != nb {
+		return na < nb
+	}
+	return a < b
+}

--- a/internal/goldext/wikilink_test.go
+++ b/internal/goldext/wikilink_test.go
@@ -1,0 +1,123 @@
+package goldext
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWikiLinkPreprocessor(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bare nested target uses last segment as label",
+			in:   "see [[02-entities/mass-spec]] now",
+			want: "see [mass-spec](/02-entities/mass-spec) now",
+		},
+		{
+			name: "explicit label",
+			in:   "[[02-entities/mass-spec|Mass Spectrometer 3]]",
+			want: "[Mass Spectrometer 3](/02-entities/mass-spec)",
+		},
+		{
+			name: "anchor on a page",
+			in:   "[[notes#results]]",
+			want: "[notes](/notes#results)",
+		},
+		{
+			name: "in-page anchor only",
+			in:   "[[#summary]]",
+			want: "[summary](#summary)",
+		},
+		{
+			name: "already-absolute target is preserved",
+			in:   "[[/03-lab-tasks|Tasks]]",
+			want: "[Tasks](/03-lab-tasks)",
+		},
+		{
+			name: "embed form is left untouched",
+			in:   "![[diagram.png]]",
+			want: "![[diagram.png]]",
+		},
+		{
+			name: "code span is not processed",
+			in:   "use `[[literal]]` here",
+			want: "use `[[literal]]` here",
+		},
+		{
+			name: "fenced code block is not processed",
+			in:   "```\n[[literal]]\n```",
+			want: "```\n[[literal]]\n```",
+		},
+		{
+			name: "two links on one line",
+			in:   "[[a]] and [[b|Bee]]",
+			want: "[a](/a) and [Bee](/b)",
+		},
+		{
+			name: "whitespace around target and label is trimmed",
+			in:   "[[ a/b | Label ]]",
+			want: "[Label](/a/b)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WikiLinkPreprocessor(tc.in, "")
+			if got != tc.want {
+				t.Errorf("WikiLinkPreprocessor(%q)\n  got:  %q\n  want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// writePage creates data/documents/<rel>/document.md under dir.
+func writePage(t *testing.T, dir, rel string) {
+	t.Helper()
+	full := filepath.Join(dir, documentsRoot, filepath.FromSlash(rel), "document.md")
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("# "+rel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWikiLinkPreprocessor_ResolvesByName(t *testing.T) {
+	dir := t.TempDir()
+	writePage(t, dir, "02-entities/mass-spec")
+	t.Chdir(dir)
+
+	got := WikiLinkPreprocessor("see [[mass-spec]] now", "")
+	want := "see [mass-spec](/02-entities/mass-spec) now"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWikiLinkPreprocessor_BareNameNotFoundFallsBackToRoot(t *testing.T) {
+	dir := t.TempDir() // empty tree: no matching page
+	t.Chdir(dir)
+
+	got := WikiLinkPreprocessor("[[ghost]]", "")
+	want := "[ghost](/ghost)" // root-level path -> LinkPreprocessor will red-link it
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWikiLinkPreprocessor_DuplicateNameShortestPathWins(t *testing.T) {
+	dir := t.TempDir()
+	writePage(t, dir, "a/b/mass-spec") // deeper
+	writePage(t, dir, "02-entities/mass-spec")
+	t.Chdir(dir)
+
+	got := WikiLinkPreprocessor("[[mass-spec]]", "")
+	want := "[mass-spec](/02-entities/mass-spec)" // fewer segments wins
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Adds support for `[[wikilink]]` syntax, implemented as a `WikiLinkPreprocessor` that converts wikilinks into standard Markdown links before Goldmark runs — following the existing `goldext` preprocessor pattern (no new dependency, no changes to the rendering core).

Implements #118.

## Behavior

| Input | Result |
|---|---|
| `[[02-entities/mass-spec]]` | `[mass-spec](/02-entities/mass-spec)` — slash ⇒ explicit path from wiki root |
| `[[mass-spec]]` | resolved **by name** against the document tree, wherever the page is filed (shortest path wins on duplicates) |
| `[[mass-spec\|Mass Spec]]` | custom display text |
| `[[notes#results]]` / `[[#summary]]` | anchor and in-page-anchor links |
| `[[ghost]]` (no such page) | falls back to `/ghost`, so it red-links via `LinkPreprocessor` (create-on-click) |
| `` `[[x]]` ``, fenced code, `![[x]]` | left untouched |

It's registered just before `LinkPreprocessor` so generated links inherit the existing `.notfound` styling for pages that don't exist yet.

## Design notes

- **Bare-name resolution** walks `data/documents/` to build a name→path index. The build is lazy (only when a rendered page actually contains a bare `[[link]]`) and consistent with how `LinkPreprocessor` already touches the filesystem. For very large wikis this could be cached/invalidated on change — left out as premature.
- **Slug matching is exact and case-sensitive** (`[[Mass-Spec]]` ≠ `mass-spec`). Happy to relax if preferred.

## Testing

- Unit tests in `internal/goldext/wikilink_test.go`: syntax variants, name resolution into a subfolder, not-found fallback, shortest-path tie-break, code-span/embed exclusion.
- Verified end-to-end against a running server: bare and explicit links resolve, missing pages render as `.notfound`, and `` `[[x]]` `` stays literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)