### PR TITLE
Improve side panel expand/collapse behavior

### DIFF
--- a/internal/resources/static/css/navigation.css
+++ b/internal/resources/static/css/navigation.css
@@ -172,6 +172,7 @@ html, body {
 .nav-item-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 6px;
 }
 

--- a/internal/resources/static/css/navigation.css
+++ b/internal/resources/static/css/navigation.css
@@ -174,6 +174,8 @@ html, body {
     align-items: center;
     justify-content: space-between;
     gap: 6px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
 }
 
 .nav-item.directory {
@@ -181,9 +183,13 @@ html, body {
     margin-top: 4px;
 }
 
-.nav-item.active > a {
-    color: var(--primary-color);
+.nav-item.active > .nav-item-header {
     background-color: var(--hover-bg);
+    color: var(--primary-color);
+}
+
+.nav-item.active > .nav-item-header > a {
+    color: var(--primary-color);
 }
 
 .nav-children {
@@ -203,16 +209,27 @@ html, body {
     color: var(--text-color);
     text-decoration: none;
     padding: 4px 8px;
-    border-radius: 4px;
     transition: all 0.2s ease;
     position: relative;
     flex: 1;
     unicode-bidi: plaintext;
 }
 
-.nav-item a:hover {
-    color: var(--primary-hover);
+.nav-item-header:hover {
     background-color: var(--hover-bg);
+    color: var(--primary-hover);
+}
+
+.nav-item-header:hover > a {
+    color: inherit;
+}
+
+.nav-item.active > .nav-item-header:hover {
+    color: var(--primary-color);
+}
+
+.nav-item.active > .nav-item-header > a:hover {
+    color: var(--primary-color);
 }
 
 /* Arrow indicator */

--- a/internal/resources/static/css/navigation.css
+++ b/internal/resources/static/css/navigation.css
@@ -169,6 +169,12 @@ html, body {
     border-radius: 4px;
 }
 
+.nav-item-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .nav-item.directory {
     font-weight: 600;
     margin-top: 4px;
@@ -180,24 +186,26 @@ html, body {
 }
 
 .nav-children {
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: 2px;
     margin-top: 2px;
     border-left: 2px solid var(--border-color);
 }
 
+/* Show children when the parent nav item is expanded */
+.nav-item.open > .nav-children {
+    display: flex;
+}
+
 .nav-item a {
     color: var(--text-color);
     text-decoration: none;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
     padding: 4px 8px;
     border-radius: 4px;
     transition: all 0.2s ease;
     position: relative;
-    gap: 6px;
+    flex: 1;
     unicode-bidi: plaintext;
 }
 
@@ -208,7 +216,21 @@ html, body {
 
 /* Arrow indicator */
 .nav-arrow {
-    display: inline-block;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    width: 26px;
+    height: 24px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+}
+
+.nav-arrow::before {
+    content: '';
     width: 0;
     height: 0;
     border: solid currentColor;
@@ -219,8 +241,8 @@ html, body {
     transition: transform 0.2s ease;
 }
 
-/* Rotate arrow down when directory is expanded (active) */
-.nav-item.active > a .nav-arrow, .nav-item.open > a .nav-arrow {
+/* Rotate arrow down when directory is expanded */
+.nav-item.open > .nav-item-header .nav-arrow::before {
     transform: rotate(45deg);
 }
 

--- a/internal/resources/static/js/sidebar-navigation.js
+++ b/internal/resources/static/js/sidebar-navigation.js
@@ -54,6 +54,8 @@
         const navItems = document.querySelector('.nav-items');
         if (!navItems) return;
 
+        const alwaysOpen = navItems.dataset.alwaysOpen === 'true';
+
         // Event delegation so it keeps working after refreshSidebar() re-renders the nav
         navItems.addEventListener('click', function(e) {
             const arrow = e.target.closest('.nav-arrow');
@@ -64,6 +66,26 @@
 
             const navItem = arrow.closest('.nav-item');
             if (!navItem) return;
+
+            if (alwaysOpen) {
+                // Preserve behavior where the arrow was inside the link: clicking
+                // the arrow navigates to the directory page rather than toggling.
+                const link = navItem.querySelector(':scope > .nav-item-header > a');
+                if (!link || !link.href) return;
+
+                // Approximate native anchor semantics for modifier / middle
+                // clicks. Programmatic MouseEvents don't reliably honor
+                // modifier flags, so open a new tab explicitly instead.
+                const openInNewTab = e.ctrlKey || e.metaKey || e.button === 1;
+                if (openInNewTab) {
+                    window.open(link.href, '_blank');
+                } else if (e.shiftKey) {
+                    window.open(link.href, '_blank', 'noopener');
+                } else {
+                    window.location.href = link.href;
+                }
+                return;
+            }
 
             const isOpen = navItem.classList.toggle('open');
             arrow.setAttribute('aria-expanded', isOpen);
@@ -83,7 +105,15 @@
     }
 
     function saveNavState() {
-        if (!sidebar) return;
+        const navItems = sidebar ? sidebar.querySelector('.nav-items') : null;
+        if (!navItems) return;
+
+        const alwaysOpen = navItems.dataset.alwaysOpen === 'true';
+        if (alwaysOpen) {
+            // When all directories are always expanded, there is no user
+            // collapse/expand state to persist.
+            return;
+        }
 
         let state = {};
         try {
@@ -92,7 +122,7 @@
             state = {};
         }
 
-        sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
+        navItems.querySelectorAll('.nav-item.directory').forEach(item => {
             const path = navItemPath(item);
             if (!path) return;
 
@@ -120,6 +150,10 @@
             : container.querySelector('.nav-items');
         const alwaysOpen = navItems && navItems.dataset.alwaysOpen === 'true';
 
+        // In always-open mode, the server renders every directory as expanded.
+        // Don't touch anything so the old behavior is preserved.
+        if (alwaysOpen) return;
+
         let state = {};
         try {
             state = JSON.parse(sessionStorage.getItem(NAV_STATE_STORAGE_KEY) || '{}');
@@ -139,8 +173,6 @@
             } else if (path && state.hasOwnProperty(path)) {
                 // Honor explicit expand/collapse choices made by the user.
                 isOpen = state[path];
-            } else if (alwaysOpen) {
-                isOpen = true;
             } else {
                 // First visit to this directory: keep it collapsed.
                 isOpen = false;

--- a/internal/resources/static/js/sidebar-navigation.js
+++ b/internal/resources/static/js/sidebar-navigation.js
@@ -43,6 +43,9 @@
         applyNavState();
         initTouchGestures();
         scrollActiveIntoView();
+
+        // Persist state before the page unloads (handles all navigation paths)
+        window.addEventListener('pagehide', saveNavState);
     });
 
     // ========== NAV EXPAND/COLLAPSE ==========
@@ -71,17 +74,31 @@
     // ========== NAV STATE PERSISTENCE ==========
 
     function navItemPath(item) {
-        const link = item.querySelector(':scope > a');
-        return link ? link.getAttribute('href') : null;
+        const link = item.querySelector(':scope > .nav-item-header > a');
+        if (!link) return null;
+
+        // Use pathname to get a consistent relative path from the root
+        // This avoids issues with absolute vs relative URLs
+        return new URL(link.href, window.location.origin).pathname;
     }
 
     function saveNavState() {
         if (!sidebar) return;
-        const state = {};
+
+        let state = {};
+        try {
+            state = JSON.parse(sessionStorage.getItem(NAV_STATE_STORAGE_KEY) || '{}');
+        } catch (e) {
+            state = {};
+        }
+
         sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
             const path = navItemPath(item);
-            if (path) state[path] = item.classList.contains('open');
+            if (path) {
+                state[path] = item.classList.contains('open');
+            }
         });
+
         try {
             sessionStorage.setItem(NAV_STATE_STORAGE_KEY, JSON.stringify(state));
         } catch (e) {
@@ -89,39 +106,40 @@
         }
     }
 
-    function applyNavState() {
-        if (!sidebar) return;
+    function applyNavState(container) {
+        container = container || sidebar;
+        if (!container) return;
+
+        const navItems = container.classList && container.classList.contains('nav-items')
+            ? container
+            : container.querySelector('.nav-items');
+        const alwaysOpen = navItems && navItems.dataset.alwaysOpen === 'true';
+
         let state = {};
         try {
             state = JSON.parse(sessionStorage.getItem(NAV_STATE_STORAGE_KEY) || '{}');
         } catch (e) {
             state = {};
         }
-        sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
+
+        container.querySelectorAll('.nav-item.directory').forEach(item => {
             const path = navItemPath(item);
+            const hasActiveChild = item.querySelector('.nav-item.active') !== null || item.classList.contains('active');
+
+            let isOpen;
             if (path && state.hasOwnProperty(path)) {
-                const persistedOpen = state[path];
-                const serverOpen = item.classList.contains('open');
-
-                // If persisted state differs from server default:
-                if (persistedOpen !== serverOpen) {
-                    // Special case: If server says open (active path),
-                    // only collapse if it's NOT actually active.
-                    if (!persistedOpen && serverOpen) {
-                        if (!item.classList.contains('active') && !item.querySelector('.nav-item.active')) {
-                            item.classList.remove('open');
-                        }
-                    } else if (persistedOpen && !serverOpen) {
-                        item.classList.add('open');
-                    }
-                }
-
-                // Update arrow aria state to match final class
-                const arrow = item.querySelector('.nav-arrow');
-                if (arrow) {
-                    arrow.setAttribute('aria-expanded', item.classList.contains('open'));
-                }
+                // Honor explicit expand/collapse choices made by the user.
+                isOpen = state[path];
+            } else if (alwaysOpen) {
+                isOpen = true;
+            } else {
+                // First visit to this directory: expand only the active branch.
+                isOpen = hasActiveChild;
             }
+
+            item.classList.toggle('open', isOpen);
+            const arrow = item.querySelector('.nav-arrow');
+            if (arrow) arrow.setAttribute('aria-expanded', String(isOpen));
         });
     }
 
@@ -204,6 +222,9 @@
             link.addEventListener('click', function(e) {
                 // Let the nav expand/collapse toggle handle arrow clicks
                 if (e.target.closest('.nav-arrow')) return;
+
+                // Persist all directory states before navigation
+                saveNavState();
 
                 // Close sidebar on mobile when link is clicked
                 if (window.innerWidth <= 768) {
@@ -520,8 +541,18 @@
         }
     }
 
+    // Apply persisted state as early as possible when this script is loaded
+    // directly after the nav tree markup, so the tree is rendered in its final
+    // expanded/collapsed form before the browser paints.
+    (function applyNavStateEarly() {
+        const earlyNavItems = document.querySelector('.nav-items');
+        if (earlyNavItems) {
+            applyNavState(earlyNavItems);
+        }
+    })();
+
     // ========== PUBLIC API ==========
-    
+
     window.SidebarNavigation = {
         toggleSidebar: toggleSidebar,
         openSidebar: openSidebar,

--- a/internal/resources/static/js/sidebar-navigation.js
+++ b/internal/resources/static/js/sidebar-navigation.js
@@ -5,6 +5,9 @@
 
     // ========== MODULE STATE ==========
     let hamburger, sidebar, content, body;
+
+    // Storage key for persisting sidebar directory states
+    const NAV_STATE_STORAGE_KEY = 'wikiGo.sidebarNavState';
     
     // Touch gesture state
     let touchStartX = 0, touchEndX = 0;
@@ -36,9 +39,91 @@
         initHamburgerMenu();
         initClickOutside();
         initSidebarLinks();
+        initNavExpandCollapse();
+        applyNavState();
         initTouchGestures();
         scrollActiveIntoView();
     });
+
+    // ========== NAV EXPAND/COLLAPSE ==========
+
+    function initNavExpandCollapse() {
+        const navItems = document.querySelector('.nav-items');
+        if (!navItems) return;
+
+        // Event delegation so it keeps working after refreshSidebar() re-renders the nav
+        navItems.addEventListener('click', function(e) {
+            const arrow = e.target.closest('.nav-arrow');
+            if (!arrow) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const navItem = arrow.closest('.nav-item');
+            if (!navItem) return;
+
+            const isOpen = navItem.classList.toggle('open');
+            arrow.setAttribute('aria-expanded', isOpen);
+            saveNavState();
+        });
+    }
+
+    // ========== NAV STATE PERSISTENCE ==========
+
+    function navItemPath(item) {
+        const link = item.querySelector(':scope > a');
+        return link ? link.getAttribute('href') : null;
+    }
+
+    function saveNavState() {
+        if (!sidebar) return;
+        const state = {};
+        sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
+            const path = navItemPath(item);
+            if (path) state[path] = item.classList.contains('open');
+        });
+        try {
+            sessionStorage.setItem(NAV_STATE_STORAGE_KEY, JSON.stringify(state));
+        } catch (e) {
+            // Ignore storage errors (e.g. private mode / quota)
+        }
+    }
+
+    function applyNavState() {
+        if (!sidebar) return;
+        let state = {};
+        try {
+            state = JSON.parse(sessionStorage.getItem(NAV_STATE_STORAGE_KEY) || '{}');
+        } catch (e) {
+            state = {};
+        }
+        sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
+            const path = navItemPath(item);
+            if (path && state.hasOwnProperty(path)) {
+                const persistedOpen = state[path];
+                const serverOpen = item.classList.contains('open');
+
+                // If persisted state differs from server default:
+                if (persistedOpen !== serverOpen) {
+                    // Special case: If server says open (active path),
+                    // only collapse if it's NOT actually active.
+                    if (!persistedOpen && serverOpen) {
+                        if (!item.classList.contains('active') && !item.querySelector('.nav-item.active')) {
+                            item.classList.remove('open');
+                        }
+                    } else if (persistedOpen && !serverOpen) {
+                        item.classList.add('open');
+                    }
+                }
+
+                // Update arrow aria state to match final class
+                const arrow = item.querySelector('.nav-arrow');
+                if (arrow) {
+                    arrow.setAttribute('aria-expanded', item.classList.contains('open'));
+                }
+            }
+        });
+    }
 
     // ========== SIDEBAR CORE FUNCTIONS ==========
     
@@ -116,7 +201,10 @@
         if (!sidebar) return;
 
         sidebar.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', function() {
+            link.addEventListener('click', function(e) {
+                // Let the nav expand/collapse toggle handle arrow clicks
+                if (e.target.closest('.nav-arrow')) return;
+
                 // Close sidebar on mobile when link is clicked
                 if (window.innerWidth <= 768) {
                     closeSidebar();
@@ -424,6 +512,7 @@
                 if (navItems) {
                     navItems.innerHTML = newSidebar.innerHTML;
                     initSidebarLinks(); // Reinitialize click handlers
+                    applyNavState();    // Reapply persisted collapsed state
                 }
             }
         } catch (error) {

--- a/internal/resources/static/js/sidebar-navigation.js
+++ b/internal/resources/static/js/sidebar-navigation.js
@@ -94,9 +94,14 @@
 
         sidebar.querySelectorAll('.nav-item.directory').forEach(item => {
             const path = navItemPath(item);
-            if (path) {
-                state[path] = item.classList.contains('open');
-            }
+            if (!path) return;
+
+            // Don't persist the forced-open state of the active page's
+            // ancestors; that state is derived from the current page and
+            // should not be treated as a user's explicit choice.
+            if (item.querySelector('.nav-item.active') !== null) return;
+
+            state[path] = item.classList.contains('open');
         });
 
         try {
@@ -124,17 +129,21 @@
 
         container.querySelectorAll('.nav-item.directory').forEach(item => {
             const path = navItemPath(item);
-            const hasActiveChild = item.querySelector('.nav-item.active') !== null || item.classList.contains('active');
+            const hasActiveDescendant = item.querySelector('.nav-item.active') !== null;
 
             let isOpen;
-            if (path && state.hasOwnProperty(path)) {
+            if (hasActiveDescendant) {
+                // The active page must always be visible: expand its ancestors
+                // regardless of any previously persisted collapse state.
+                isOpen = true;
+            } else if (path && state.hasOwnProperty(path)) {
                 // Honor explicit expand/collapse choices made by the user.
                 isOpen = state[path];
             } else if (alwaysOpen) {
                 isOpen = true;
             } else {
-                // First visit to this directory: expand only the active branch.
-                isOpen = hasActiveChild;
+                // First visit to this directory: keep it collapsed.
+                isOpen = false;
             }
 
             item.classList.toggle('open', isOpen);

--- a/internal/resources/templates/base.html
+++ b/internal/resources/templates/base.html
@@ -268,7 +268,6 @@
     </div>
 
     <script src="/static/js/dialog-system.js?={{getVersion}}"></script>
-    <script src="/static/js/sidebar-navigation.js?={{getVersion}}"></script>
     <script src="/static/js/file-utilities.js?={{getVersion}}"></script>
     <script src="/static/js/file-upload.js?={{getVersion}}"></script>
     <script src="/static/js/version-history.js?={{getVersion}}"></script>

--- a/internal/resources/templates/nav-items.html
+++ b/internal/resources/templates/nav-items.html
@@ -1,13 +1,14 @@
 {{define "nav-items"}}
     {{$open := .AlwaysOpen}}
     {{range .Root.Children}}
-        <div class="nav-item {{if .IsDir}}directory{{end}} {{if .IsActive}}active{{end}} {{if $open}}open{{end}}">
-            <a href="{{.Path}}">
-                {{.Title}}
-                {{/* Show arrow if this item is a directory and has children */}}
-                {{if and .IsDir (gt (len .Children) 0)}}<span class="nav-arrow" aria-hidden="true"></span>{{end}}
-            </a>
-            {{if and .IsDir .Children (or .IsActive $open)}}
+        <div class="nav-item {{if .IsDir}}directory{{end}} {{if .IsActive}}active{{end}} {{if or .IsActive $open}}open{{end}}">
+            <div class="nav-item-header">
+                {{if and .IsDir (gt (len .Children) 0)}}
+                    <button class="nav-arrow" aria-label="Toggle {{.Title}}" aria-expanded="{{if or .IsActive $open}}true{{else}}false{{end}}"></button>
+                {{end}}
+                <a href="{{.Path}}">{{.Title}}</a>
+            </div>
+            {{if and .IsDir .Children}}
                 <div class="nav-children" style="padding-left: 16px;">
                     {{template "nav-items" (dict "Root" . "AlwaysOpen" $open)}}
                 </div>

--- a/internal/resources/templates/nav-items.html
+++ b/internal/resources/templates/nav-items.html
@@ -3,10 +3,10 @@
     {{range .Root.Children}}
         <div class="nav-item {{if .IsDir}}directory{{end}} {{if .IsActive}}active{{end}} {{if or .IsActive $open}}open{{end}}">
             <div class="nav-item-header">
+                <a href="{{.Path}}">{{.Title}}</a>
                 {{if and .IsDir (gt (len .Children) 0)}}
                     <button class="nav-arrow" aria-label="Toggle {{.Title}}" aria-expanded="{{if or .IsActive $open}}true{{else}}false{{end}}"></button>
                 {{end}}
-                <a href="{{.Path}}">{{.Title}}</a>
             </div>
             {{if and .IsDir .Children}}
                 <div class="nav-children" style="padding-left: 16px;">

--- a/internal/resources/templates/sidebar.html
+++ b/internal/resources/templates/sidebar.html
@@ -17,9 +17,10 @@
             <input type="text" class="search-box" placeholder='{{t "common.search"}}...' aria-label="{{t "common.search"}}">
         </div>
     </div>
-    <div class="nav-items">
+    <div class="nav-items" data-always-open="{{.Navigation.AlwaysOpen}}">
         {{template "nav-items" .Navigation}}
     </div>
+    <script src="/static/js/sidebar-navigation.js?={{getVersion}}"></script>
     <div class="sidebar-footer">
         <div class="owner">{{.Config.Wiki.Owner}}</div>
         <div class="notice">{{processShortcodes .Config.Wiki.Notice}}</div>


### PR DESCRIPTION
Implement expand/collapse behavior in side panel navigation items
replacing the previous always-open behavior. Each section can now be                                                    
toggled with the open/closed state persisted in sessionStorage so it
survives navigation and page refreshes. When a nested page is accessed
directly by URL the parent pages will be expanded so the current page
will be visible in the side panel tree.